### PR TITLE
Remove the derivative proc-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -278,7 +278,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -323,17 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +340,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -507,7 +496,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -831,7 +820,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1101,7 +1090,6 @@ name = "poise"
 version = "0.6.1"
 dependencies = [
  "async-trait",
- "derivative",
  "fluent",
  "fluent-syntax",
  "futures",
@@ -1126,7 +1114,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1484,7 +1472,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1636,17 +1624,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
@@ -1670,7 +1647,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1730,7 +1707,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1808,7 +1785,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1887,7 +1864,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2011,7 +1988,7 @@ checksum = "fd9fc0ad9e03a2b0c2e2a0eafaecccef2121829e1ab6ce9c9d790e6c6766bd1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2139,7 +2116,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2173,7 +2150,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2452,7 +2429,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "synstructure",
 ]
 
@@ -2474,7 +2451,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2494,7 +2471,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "synstructure",
 ]
 
@@ -2523,5 +2500,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ poise_macros = { path = "macros", version = "0.6.1" } # remember to update the v
 async-trait = { version = "0.1.48", default-features = false } # various traits
 regex = { version = "1.6.0", default-features = false, features = ["std"] } # prefix
 tracing = { version = "0.1.40", features = ["log"] } # warning about weird state
-derivative = "2.2.0"
 parking_lot = "0.12.1"
 trim-in-place = "0.1.7"
 indexmap = "2.2.6"

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -1,24 +1,24 @@
 //! The Command struct, which stores all information about a single framework command
 
+use std::fmt::Debug;
+
 use crate::{serenity_prelude as serenity, BoxFuture};
 
 use super::{CowStr, CowVec};
 
 /// Type returned from `#[poise::command]` annotated functions, which contains all of the generated
 /// prefix and application commands
-#[derive(derivative::Derivative)]
-#[derivative(Default(bound = ""), Debug(bound = ""))]
 pub struct Command<U, E> {
     // =============
     /// Callback to execute when this command is invoked in a prefix context
-    #[derivative(Debug = "ignore")]
+    //#[derivative(Debug = "ignore")]
     pub prefix_action: Option<
         for<'a> fn(
             crate::PrefixContext<'a, U, E>,
         ) -> BoxFuture<'a, Result<(), crate::FrameworkError<'a, U, E>>>,
     >,
     /// Callback to execute when this command is invoked in a slash context
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub slash_action: Option<
         for<'a> fn(
             crate::ApplicationContext<'a, U, E>,
@@ -107,17 +107,17 @@ pub struct Command<U, E> {
     /// If true, the command may only run in NSFW channels
     pub nsfw_only: bool,
     /// Command-specific override for [`crate::FrameworkOptions::on_error`]
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub on_error: Option<fn(crate::FrameworkError<'_, U, E>) -> BoxFuture<'_, ()>>,
     /// If any of these functions returns false, this command will not be executed.
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub checks: Vec<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
     /// List of parameters for this command
     ///
     /// Used for registering and parsing slash commands. Can also be used in help commands
     pub parameters: Vec<crate::CommandParameter<U, E>>,
     /// Arbitrary data, useful for storing custom metadata about your commands
-    #[derivative(Default(value = "Box::new(())"))]
+    // #[derivative(Default(value = "Box::new(())"))]
     pub custom_data: Box<dyn std::any::Any + Send + Sync>,
 
     // ============= Prefix-specific data
@@ -143,6 +143,49 @@ pub struct Command<U, E> {
     // Like #[non_exhaustive], but #[poise::command] still needs to be able to create an instance
     #[doc(hidden)]
     pub __non_exhaustive: (),
+}
+
+// manual Debug impl to remove use of derivative proc macro
+impl<U: Debug, E: Debug> Debug for Command<U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Command")
+            .field("context_menu_action", &self.context_menu_action)
+            .field("subcommands", &self.subcommands)
+            .field("subcommand_required", &self.subcommand_required)
+            .field("name", &self.name)
+            .field("name_localizations", &self.name_localizations)
+            .field("qualified_name", &self.qualified_name)
+            .field("identifying_name", &self.identifying_name)
+            .field("source_code_name", &self.source_code_name)
+            .field("category", &self.category)
+            .field("hide_in_help", &self.hide_in_help)
+            .field("description", &self.description)
+            .field("description_localizations", &self.description_localizations)
+            .field("help_text", &self.help_text)
+            .field("manual_cooldowns", &self.manual_cooldowns)
+            .field("cooldowns", &self.cooldowns)
+            .field("cooldown_config", &self.cooldown_config)
+            .field("reuse_response", &self.reuse_response)
+            .field("default_member_permissions", &self.default_member_permissions)
+            .field("required_permissions", &self.required_permissions)
+            .field("required_bot_permissions", &self.required_bot_permissions)
+            .field("owners_only", &self.owners_only)
+            .field("guild_only", &self.guild_only)
+            .field("dm_only", &self.dm_only)
+            .field("nsfw_only", &self.nsfw_only)
+            .field("parameters", &self.parameters)
+            .field("custom_data", &self.custom_data)
+            .field("aliases", &self.aliases)
+            .field("invoke_on_edit", &self.invoke_on_edit)
+            .field("track_deletion", &self.track_deletion)
+            .field("broadcast_typing", &self.broadcast_typing)
+            .field("context_menu_name", &self.context_menu_name)
+            .field("ephemeral", &self.ephemeral)
+            .field("install_context", &self.install_context)
+            .field("interaction_context", &self.interaction_context)
+            .field("__non_exhaustive", &self.__non_exhaustive)
+            .finish()
+    }
 }
 
 impl<U, E> PartialEq for Command<U, E> {

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -162,7 +162,10 @@ impl<U, E> Debug for Command<U, E> {
             .field("cooldowns", &self.cooldowns)
             .field("cooldown_config", &self.cooldown_config)
             .field("reuse_response", &self.reuse_response)
-            .field("default_member_permissions", &self.default_member_permissions)
+            .field(
+                "default_member_permissions",
+                &self.default_member_permissions,
+            )
             .field("required_permissions", &self.required_permissions)
             .field("required_bot_permissions", &self.required_bot_permissions)
             .field("owners_only", &self.owners_only)
@@ -224,7 +227,8 @@ impl<U, E> Default for Command<U, E> {
             ephemeral: false,
             install_context: None,
             interaction_context: None,
-            __non_exhaustive: () }
+            __non_exhaustive: (),
+        }
     }
 }
 

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -11,14 +11,12 @@ use super::{CowStr, CowVec};
 pub struct Command<U, E> {
     // =============
     /// Callback to execute when this command is invoked in a prefix context
-    //#[derivative(Debug = "ignore")]
     pub prefix_action: Option<
         for<'a> fn(
             crate::PrefixContext<'a, U, E>,
         ) -> BoxFuture<'a, Result<(), crate::FrameworkError<'a, U, E>>>,
     >,
     /// Callback to execute when this command is invoked in a slash context
-    // #[derivative(Debug = "ignore")]
     pub slash_action: Option<
         for<'a> fn(
             crate::ApplicationContext<'a, U, E>,
@@ -107,10 +105,8 @@ pub struct Command<U, E> {
     /// If true, the command may only run in NSFW channels
     pub nsfw_only: bool,
     /// Command-specific override for [`crate::FrameworkOptions::on_error`]
-    // #[derivative(Debug = "ignore")]
     pub on_error: Option<fn(crate::FrameworkError<'_, U, E>) -> BoxFuture<'_, ()>>,
     /// If any of these functions returns false, this command will not be executed.
-    // #[derivative(Debug = "ignore")]
     pub checks: Vec<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
     /// List of parameters for this command
     ///
@@ -146,7 +142,7 @@ pub struct Command<U, E> {
 }
 
 // manual Debug impl to remove use of derivative proc macro
-impl<U: Debug, E: Debug> Debug for Command<U, E> {
+impl<U, E> Debug for Command<U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Command")
             .field("context_menu_action", &self.context_menu_action)
@@ -183,8 +179,52 @@ impl<U: Debug, E: Debug> Debug for Command<U, E> {
             .field("ephemeral", &self.ephemeral)
             .field("install_context", &self.install_context)
             .field("interaction_context", &self.interaction_context)
-            .field("__non_exhaustive", &self.__non_exhaustive)
-            .finish()
+            .finish_non_exhaustive()
+    }
+}
+
+impl<U, E> Default for Command<U, E> {
+    fn default() -> Self {
+        Self {
+            prefix_action: None,
+            slash_action: None,
+            context_menu_action: None,
+            subcommands: vec![],
+            subcommand_required: false,
+            name: CowStr::default(),
+            name_localizations: CowVec::default(),
+            qualified_name: CowStr::default(),
+            identifying_name: CowStr::default(),
+            source_code_name: CowStr::default(),
+            category: None,
+            hide_in_help: false,
+            description: None,
+            description_localizations: CowVec::default(),
+            help_text: None,
+            manual_cooldowns: None,
+            cooldowns: std::sync::Mutex::default(),
+            cooldown_config: std::sync::RwLock::default(),
+            reuse_response: false,
+            default_member_permissions: serenity::Permissions::default(),
+            required_permissions: serenity::Permissions::default(),
+            required_bot_permissions: serenity::Permissions::default(),
+            owners_only: false,
+            guild_only: false,
+            dm_only: false,
+            nsfw_only: false,
+            on_error: None,
+            checks: vec![],
+            parameters: vec![],
+            custom_data: Box::new(()),
+            aliases: CowVec::default(),
+            invoke_on_edit: false,
+            track_deletion: false,
+            broadcast_typing: false,
+            context_menu_name: None,
+            ephemeral: false,
+            install_context: None,
+            interaction_context: None,
+            __non_exhaustive: () }
     }
 }
 

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -208,102 +208,122 @@ pub enum FrameworkError<'a, U, E> {
 impl<'a, U: Debug, E: Debug> Debug for FrameworkError<'_, U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Setup { error, framework, data_about_bot, ctx } =>
-                f.debug_struct("Setup")
-                    .field("error", error)
-                    .field("data_about_bot", data_about_bot)
-                    .finish_non_exhaustive(),
-            Self::EventHandler { error, event, framework } =>
-                f.debug_struct("EventHandler")
-                    .field("error", error)
-                    .field("event", event)
-                    .finish_non_exhaustive(),
-            Self::Command { error, ctx } =>
-                f.debug_struct("Command")
-                    .field("error", error)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::SubcommandRequired { ctx } =>
-                f.debug_struct("SubcommandRequired")
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::CommandPanic { payload, ctx } =>
-                f.debug_struct("CommandPanic")
-                    .field("payload", payload)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::ArgumentParse { error, input, ctx } =>
-                f.debug_struct("ArgumentParse")
-                    .field("error", error)
-                    .field("input", input)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::CommandStructureMismatch { description, ctx } =>
-                f.debug_struct("CommandStructureMismatch")
-                    .field("description", description)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::CooldownHit { remaining_cooldown, ctx } =>
-                f.debug_struct("CooldownHit")
-                    .field("remaining_cooldown", remaining_cooldown)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::MissingBotPermissions { missing_permissions, ctx } =>
-                f.debug_struct("MissingBotPermissions")
-                    .field("missing_permissions", missing_permissions)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::MissingUserPermissions { missing_permissions, ctx } =>
-                f.debug_struct("MissingUserPermissions")
-                    .field("missing_permissions", missing_permissions)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::PermissionFetchFailed { ctx } =>
-                f.debug_struct("PermissionFetchFailed")
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::NotAnOwner { ctx } =>
-                f.debug_struct("NotAnOwner")
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::GuildOnly { ctx } =>
-                f.debug_struct("GuildOnly")
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::DmOnly { ctx } =>
-                f.debug_struct("DmOnly")
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::NsfwOnly { ctx } =>
-                f.debug_struct("NsfwOnly")
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::CommandCheckFailed { error, ctx } =>
-                f.debug_struct("CommandCheckFailed")
-                    .field("error", error)
-                    .field("ctx", ctx)
-                    .finish(),
-            Self::DynamicPrefix { error, ctx, msg } =>
-                f.debug_struct("DynamicPrefix")
-                    .field("error", error)
-                    .field("msg", msg)
-                    .finish_non_exhaustive(),
-            Self::UnknownCommand { msg, prefix, msg_content, framework, invocation_data, trigger } =>
-                f.debug_struct("UnknownCommand")
-                    .field("msg", msg)
-                    .field("prefix", prefix)
-                    .field("msg_content", msg_content)
-                    .field("trigger", trigger)
-                    .finish_non_exhaustive(),
-            Self::UnknownInteraction { framework, interaction } =>
-                f.debug_struct("UnknownInteraction")
-                    .field("interaction", interaction)
-                    .finish_non_exhaustive(),
-            Self::NonCommandMessage { error, framework, msg } =>
-                f.debug_struct("NonCommandMessage")
-                    .field("error", error)
-                    .field("msg", msg)
-                    .finish_non_exhaustive(),
+            Self::Setup {
+                error,
+                framework,
+                data_about_bot,
+                ctx,
+            } => f
+                .debug_struct("Setup")
+                .field("error", error)
+                .field("data_about_bot", data_about_bot)
+                .finish_non_exhaustive(),
+            Self::EventHandler {
+                error,
+                event,
+                framework,
+            } => f
+                .debug_struct("EventHandler")
+                .field("error", error)
+                .field("event", event)
+                .finish_non_exhaustive(),
+            Self::Command { error, ctx } => f
+                .debug_struct("Command")
+                .field("error", error)
+                .field("ctx", ctx)
+                .finish(),
+            Self::SubcommandRequired { ctx } => f
+                .debug_struct("SubcommandRequired")
+                .field("ctx", ctx)
+                .finish(),
+            Self::CommandPanic { payload, ctx } => f
+                .debug_struct("CommandPanic")
+                .field("payload", payload)
+                .field("ctx", ctx)
+                .finish(),
+            Self::ArgumentParse { error, input, ctx } => f
+                .debug_struct("ArgumentParse")
+                .field("error", error)
+                .field("input", input)
+                .field("ctx", ctx)
+                .finish(),
+            Self::CommandStructureMismatch { description, ctx } => f
+                .debug_struct("CommandStructureMismatch")
+                .field("description", description)
+                .field("ctx", ctx)
+                .finish(),
+            Self::CooldownHit {
+                remaining_cooldown,
+                ctx,
+            } => f
+                .debug_struct("CooldownHit")
+                .field("remaining_cooldown", remaining_cooldown)
+                .field("ctx", ctx)
+                .finish(),
+            Self::MissingBotPermissions {
+                missing_permissions,
+                ctx,
+            } => f
+                .debug_struct("MissingBotPermissions")
+                .field("missing_permissions", missing_permissions)
+                .field("ctx", ctx)
+                .finish(),
+            Self::MissingUserPermissions {
+                missing_permissions,
+                ctx,
+            } => f
+                .debug_struct("MissingUserPermissions")
+                .field("missing_permissions", missing_permissions)
+                .field("ctx", ctx)
+                .finish(),
+            Self::PermissionFetchFailed { ctx } => f
+                .debug_struct("PermissionFetchFailed")
+                .field("ctx", ctx)
+                .finish(),
+            Self::NotAnOwner { ctx } => f.debug_struct("NotAnOwner").field("ctx", ctx).finish(),
+            Self::GuildOnly { ctx } => f.debug_struct("GuildOnly").field("ctx", ctx).finish(),
+            Self::DmOnly { ctx } => f.debug_struct("DmOnly").field("ctx", ctx).finish(),
+            Self::NsfwOnly { ctx } => f.debug_struct("NsfwOnly").field("ctx", ctx).finish(),
+            Self::CommandCheckFailed { error, ctx } => f
+                .debug_struct("CommandCheckFailed")
+                .field("error", error)
+                .field("ctx", ctx)
+                .finish(),
+            Self::DynamicPrefix { error, ctx, msg } => f
+                .debug_struct("DynamicPrefix")
+                .field("error", error)
+                .field("msg", msg)
+                .finish_non_exhaustive(),
+            Self::UnknownCommand {
+                msg,
+                prefix,
+                msg_content,
+                framework,
+                invocation_data,
+                trigger,
+            } => f
+                .debug_struct("UnknownCommand")
+                .field("msg", msg)
+                .field("prefix", prefix)
+                .field("msg_content", msg_content)
+                .field("trigger", trigger)
+                .finish_non_exhaustive(),
+            Self::UnknownInteraction {
+                framework,
+                interaction,
+            } => f
+                .debug_struct("UnknownInteraction")
+                .field("interaction", interaction)
+                .finish_non_exhaustive(),
+            Self::NonCommandMessage {
+                error,
+                framework,
+                msg,
+            } => f
+                .debug_struct("NonCommandMessage")
+                .field("error", error)
+                .field("msg", msg)
+                .finish_non_exhaustive(),
             Self::__NonExhaustive(arg0) => write!(f, "Infallible"),
         }
     }

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -1,13 +1,13 @@
 //! Simple module for the `FrameworkError` struct and its impls
 
+use std::fmt::Debug;
+
 use crate::serenity_prelude as serenity;
 
 /// Any error that can occur while the bot runs. Either thrown by user code (those variants will
 /// have an `error` field with your error type `E` in it), or originating from within the framework.
 ///
 /// These errors are handled with the [`crate::FrameworkOptions::on_error`] callback
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub enum FrameworkError<'a, U, E> {
     /// User code threw an error in user data setup
     #[non_exhaustive]
@@ -15,12 +15,12 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the setup code
         error: E,
         /// The Framework passed to the event
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         framework: &'a crate::Framework<U, E>,
         /// Discord Ready event data present during setup
         data_about_bot: &'a serenity::Ready,
         /// The serenity Context passed to the event
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         ctx: &'a serenity::Context,
     },
     /// User code threw an error in generic event event handler
@@ -31,7 +31,7 @@ pub enum FrameworkError<'a, U, E> {
         /// Which event was being processed when the error occurred
         event: &'a serenity::FullEvent,
         /// The Framework passed to the event
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
     },
     /// Error occurred during command execution
@@ -161,7 +161,7 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the dynamic prefix code
         error: E,
         /// General context
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         ctx: crate::PartialContext<'a, U, E>,
         /// Message which the dynamic prefix callback was evaluated upon
         msg: &'a serenity::Message,
@@ -178,10 +178,10 @@ pub enum FrameworkError<'a, U, E> {
         /// This is a single field instead of two fields (command name and args) due to subcommands
         msg_content: &'a str,
         /// Framework context
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
         /// See [`crate::Context::invocation_data`]
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         invocation_data: &'a tokio::sync::Mutex<Box<dyn std::any::Any + Send + Sync>>,
         /// Which event triggered the message parsing routine
         trigger: crate::MessageDispatchTrigger,
@@ -190,7 +190,7 @@ pub enum FrameworkError<'a, U, E> {
     #[non_exhaustive]
     UnknownInteraction {
         /// Framework context
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
         /// The interaction in question
         interaction: &'a serenity::CommandInteraction,
@@ -201,7 +201,7 @@ pub enum FrameworkError<'a, U, E> {
         /// The error thrown by user code
         error: E,
         /// Framework context
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
         /// The interaction in question
         msg: &'a serenity::Message,
@@ -209,6 +209,36 @@ pub enum FrameworkError<'a, U, E> {
     // #[non_exhaustive] forbids struct update syntax for ?? reason
     #[doc(hidden)]
     __NonExhaustive(std::convert::Infallible),
+}
+
+// manual Debug impl to remove use of derivative proc macro
+#[allow(unused)]
+impl<'a, U: Debug, E: Debug> Debug for FrameworkError<'_, U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Setup { error, framework, data_about_bot, ctx } => f.debug_struct("Setup").field("error", error).field("data_about_bot", data_about_bot).finish(),
+            Self::EventHandler { error, event, framework } => f.debug_struct("EventHandler").field("error", error).field("event", event).finish(),
+            Self::Command { error, ctx } => f.debug_struct("Command").field("error", error).field("ctx", ctx).finish(),
+            Self::SubcommandRequired { ctx } => f.debug_struct("SubcommandRequired").field("ctx", ctx).finish(),
+            Self::CommandPanic { payload, ctx } => f.debug_struct("CommandPanic").field("payload", payload).field("ctx", ctx).finish(),
+            Self::ArgumentParse { error, input, ctx } => f.debug_struct("ArgumentParse").field("error", error).field("input", input).field("ctx", ctx).finish(),
+            Self::CommandStructureMismatch { description, ctx } => f.debug_struct("CommandStructureMismatch").field("description", description).field("ctx", ctx).finish(),
+            Self::CooldownHit { remaining_cooldown, ctx } => f.debug_struct("CooldownHit").field("remaining_cooldown", remaining_cooldown).field("ctx", ctx).finish(),
+            Self::MissingBotPermissions { missing_permissions, ctx } => f.debug_struct("MissingBotPermissions").field("missing_permissions", missing_permissions).field("ctx", ctx).finish(),
+            Self::MissingUserPermissions { missing_permissions, ctx } => f.debug_struct("MissingUserPermissions").field("missing_permissions", missing_permissions).field("ctx", ctx).finish(),
+            Self::PermissionFetchFailed { ctx } => f.debug_struct("PermissionFetchFailed").field("ctx", ctx).finish(),
+            Self::NotAnOwner { ctx } => f.debug_struct("NotAnOwner").field("ctx", ctx).finish(),
+            Self::GuildOnly { ctx } => f.debug_struct("GuildOnly").field("ctx", ctx).finish(),
+            Self::DmOnly { ctx } => f.debug_struct("DmOnly").field("ctx", ctx).finish(),
+            Self::NsfwOnly { ctx } => f.debug_struct("NsfwOnly").field("ctx", ctx).finish(),
+            Self::CommandCheckFailed { error, ctx } => f.debug_struct("CommandCheckFailed").field("error", error).field("ctx", ctx).finish(),
+            Self::DynamicPrefix { error, ctx, msg } => f.debug_struct("DynamicPrefix").field("error", error).field("msg", msg).finish(),
+            Self::UnknownCommand { msg, prefix, msg_content, framework, invocation_data, trigger } => f.debug_struct("UnknownCommand").field("msg", msg).field("prefix", prefix).field("msg_content", msg_content).field("trigger", trigger).finish(),
+            Self::UnknownInteraction { framework, interaction } => f.debug_struct("UnknownInteraction").field("interaction", interaction).finish(),
+            Self::NonCommandMessage { error, framework, msg } => f.debug_struct("NonCommandMessage").field("error", error).field("msg", msg).finish(),
+            Self::__NonExhaustive(arg0) => f.debug_tuple("__NonExhaustive").field(arg0).finish(),
+        }
+    }
 }
 
 impl<'a, U, E> FrameworkError<'a, U, E> {

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -15,12 +15,10 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the setup code
         error: E,
         /// The Framework passed to the event
-        // #[derivative(Debug = "ignore")]
         framework: &'a crate::Framework<U, E>,
         /// Discord Ready event data present during setup
         data_about_bot: &'a serenity::Ready,
         /// The serenity Context passed to the event
-        // #[derivative(Debug = "ignore")]
         ctx: &'a serenity::Context,
     },
     /// User code threw an error in generic event event handler
@@ -31,7 +29,6 @@ pub enum FrameworkError<'a, U, E> {
         /// Which event was being processed when the error occurred
         event: &'a serenity::FullEvent,
         /// The Framework passed to the event
-        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
     },
     /// Error occurred during command execution
@@ -161,7 +158,6 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the dynamic prefix code
         error: E,
         /// General context
-        // #[derivative(Debug = "ignore")]
         ctx: crate::PartialContext<'a, U, E>,
         /// Message which the dynamic prefix callback was evaluated upon
         msg: &'a serenity::Message,
@@ -178,10 +174,8 @@ pub enum FrameworkError<'a, U, E> {
         /// This is a single field instead of two fields (command name and args) due to subcommands
         msg_content: &'a str,
         /// Framework context
-        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
         /// See [`crate::Context::invocation_data`]
-        // #[derivative(Debug = "ignore")]
         invocation_data: &'a tokio::sync::Mutex<Box<dyn std::any::Any + Send + Sync>>,
         /// Which event triggered the message parsing routine
         trigger: crate::MessageDispatchTrigger,
@@ -190,7 +184,6 @@ pub enum FrameworkError<'a, U, E> {
     #[non_exhaustive]
     UnknownInteraction {
         /// Framework context
-        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
         /// The interaction in question
         interaction: &'a serenity::CommandInteraction,
@@ -201,7 +194,6 @@ pub enum FrameworkError<'a, U, E> {
         /// The error thrown by user code
         error: E,
         /// Framework context
-        // #[derivative(Debug = "ignore")]
         framework: crate::FrameworkContext<'a, U, E>,
         /// The interaction in question
         msg: &'a serenity::Message,
@@ -220,12 +212,12 @@ impl<'a, U: Debug, E: Debug> Debug for FrameworkError<'_, U, E> {
                 f.debug_struct("Setup")
                     .field("error", error)
                     .field("data_about_bot", data_about_bot)
-                    .finish(),
+                    .finish_non_exhaustive(),
             Self::EventHandler { error, event, framework } =>
                 f.debug_struct("EventHandler")
                     .field("error", error)
                     .field("event", event)
-                    .finish(),
+                    .finish_non_exhaustive(),
             Self::Command { error, ctx } =>
                 f.debug_struct("Command")
                     .field("error", error)
@@ -295,23 +287,23 @@ impl<'a, U: Debug, E: Debug> Debug for FrameworkError<'_, U, E> {
                 f.debug_struct("DynamicPrefix")
                     .field("error", error)
                     .field("msg", msg)
-                    .finish(),
+                    .finish_non_exhaustive(),
             Self::UnknownCommand { msg, prefix, msg_content, framework, invocation_data, trigger } =>
                 f.debug_struct("UnknownCommand")
                     .field("msg", msg)
                     .field("prefix", prefix)
                     .field("msg_content", msg_content)
                     .field("trigger", trigger)
-                    .finish(),
+                    .finish_non_exhaustive(),
             Self::UnknownInteraction { framework, interaction } =>
                 f.debug_struct("UnknownInteraction")
                     .field("interaction", interaction)
-                    .finish(),
+                    .finish_non_exhaustive(),
             Self::NonCommandMessage { error, framework, msg } =>
                 f.debug_struct("NonCommandMessage")
                     .field("error", error)
                     .field("msg", msg)
-                    .finish(),
+                    .finish_non_exhaustive(),
             Self::__NonExhaustive(arg0) => write!(f, "Infallible"),
         }
     }

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -216,27 +216,103 @@ pub enum FrameworkError<'a, U, E> {
 impl<'a, U: Debug, E: Debug> Debug for FrameworkError<'_, U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Setup { error, framework, data_about_bot, ctx } => f.debug_struct("Setup").field("error", error).field("data_about_bot", data_about_bot).finish(),
-            Self::EventHandler { error, event, framework } => f.debug_struct("EventHandler").field("error", error).field("event", event).finish(),
-            Self::Command { error, ctx } => f.debug_struct("Command").field("error", error).field("ctx", ctx).finish(),
-            Self::SubcommandRequired { ctx } => f.debug_struct("SubcommandRequired").field("ctx", ctx).finish(),
-            Self::CommandPanic { payload, ctx } => f.debug_struct("CommandPanic").field("payload", payload).field("ctx", ctx).finish(),
-            Self::ArgumentParse { error, input, ctx } => f.debug_struct("ArgumentParse").field("error", error).field("input", input).field("ctx", ctx).finish(),
-            Self::CommandStructureMismatch { description, ctx } => f.debug_struct("CommandStructureMismatch").field("description", description).field("ctx", ctx).finish(),
-            Self::CooldownHit { remaining_cooldown, ctx } => f.debug_struct("CooldownHit").field("remaining_cooldown", remaining_cooldown).field("ctx", ctx).finish(),
-            Self::MissingBotPermissions { missing_permissions, ctx } => f.debug_struct("MissingBotPermissions").field("missing_permissions", missing_permissions).field("ctx", ctx).finish(),
-            Self::MissingUserPermissions { missing_permissions, ctx } => f.debug_struct("MissingUserPermissions").field("missing_permissions", missing_permissions).field("ctx", ctx).finish(),
-            Self::PermissionFetchFailed { ctx } => f.debug_struct("PermissionFetchFailed").field("ctx", ctx).finish(),
-            Self::NotAnOwner { ctx } => f.debug_struct("NotAnOwner").field("ctx", ctx).finish(),
-            Self::GuildOnly { ctx } => f.debug_struct("GuildOnly").field("ctx", ctx).finish(),
-            Self::DmOnly { ctx } => f.debug_struct("DmOnly").field("ctx", ctx).finish(),
-            Self::NsfwOnly { ctx } => f.debug_struct("NsfwOnly").field("ctx", ctx).finish(),
-            Self::CommandCheckFailed { error, ctx } => f.debug_struct("CommandCheckFailed").field("error", error).field("ctx", ctx).finish(),
-            Self::DynamicPrefix { error, ctx, msg } => f.debug_struct("DynamicPrefix").field("error", error).field("msg", msg).finish(),
-            Self::UnknownCommand { msg, prefix, msg_content, framework, invocation_data, trigger } => f.debug_struct("UnknownCommand").field("msg", msg).field("prefix", prefix).field("msg_content", msg_content).field("trigger", trigger).finish(),
-            Self::UnknownInteraction { framework, interaction } => f.debug_struct("UnknownInteraction").field("interaction", interaction).finish(),
-            Self::NonCommandMessage { error, framework, msg } => f.debug_struct("NonCommandMessage").field("error", error).field("msg", msg).finish(),
-            Self::__NonExhaustive(arg0) => f.debug_tuple("__NonExhaustive").field(arg0).finish(),
+            Self::Setup { error, framework, data_about_bot, ctx } =>
+                f.debug_struct("Setup")
+                    .field("error", error)
+                    .field("data_about_bot", data_about_bot)
+                    .finish(),
+            Self::EventHandler { error, event, framework } =>
+                f.debug_struct("EventHandler")
+                    .field("error", error)
+                    .field("event", event)
+                    .finish(),
+            Self::Command { error, ctx } =>
+                f.debug_struct("Command")
+                    .field("error", error)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::SubcommandRequired { ctx } =>
+                f.debug_struct("SubcommandRequired")
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::CommandPanic { payload, ctx } =>
+                f.debug_struct("CommandPanic")
+                    .field("payload", payload)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::ArgumentParse { error, input, ctx } =>
+                f.debug_struct("ArgumentParse")
+                    .field("error", error)
+                    .field("input", input)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::CommandStructureMismatch { description, ctx } =>
+                f.debug_struct("CommandStructureMismatch")
+                    .field("description", description)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::CooldownHit { remaining_cooldown, ctx } =>
+                f.debug_struct("CooldownHit")
+                    .field("remaining_cooldown", remaining_cooldown)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::MissingBotPermissions { missing_permissions, ctx } =>
+                f.debug_struct("MissingBotPermissions")
+                    .field("missing_permissions", missing_permissions)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::MissingUserPermissions { missing_permissions, ctx } =>
+                f.debug_struct("MissingUserPermissions")
+                    .field("missing_permissions", missing_permissions)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::PermissionFetchFailed { ctx } =>
+                f.debug_struct("PermissionFetchFailed")
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::NotAnOwner { ctx } =>
+                f.debug_struct("NotAnOwner")
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::GuildOnly { ctx } =>
+                f.debug_struct("GuildOnly")
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::DmOnly { ctx } =>
+                f.debug_struct("DmOnly")
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::NsfwOnly { ctx } =>
+                f.debug_struct("NsfwOnly")
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::CommandCheckFailed { error, ctx } =>
+                f.debug_struct("CommandCheckFailed")
+                    .field("error", error)
+                    .field("ctx", ctx)
+                    .finish(),
+            Self::DynamicPrefix { error, ctx, msg } =>
+                f.debug_struct("DynamicPrefix")
+                    .field("error", error)
+                    .field("msg", msg)
+                    .finish(),
+            Self::UnknownCommand { msg, prefix, msg_content, framework, invocation_data, trigger } =>
+                f.debug_struct("UnknownCommand")
+                    .field("msg", msg)
+                    .field("prefix", prefix)
+                    .field("msg_content", msg_content)
+                    .field("trigger", trigger)
+                    .finish(),
+            Self::UnknownInteraction { framework, interaction } =>
+                f.debug_struct("UnknownInteraction")
+                    .field("interaction", interaction)
+                    .finish(),
+            Self::NonCommandMessage { error, framework, msg } =>
+                f.debug_struct("NonCommandMessage")
+                    .field("error", error)
+                    .field("msg", msg)
+                    .finish(),
+            Self::__NonExhaustive(arg0) => write!(f, "Infallible"),
         }
     }
 }

--- a/src/structs/framework_options.rs
+++ b/src/structs/framework_options.rs
@@ -3,25 +3,23 @@
 use crate::{serenity_prelude as serenity, BoxFuture};
 
 /// Framework configuration
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct FrameworkOptions<U, E> {
     /// List of commands in the framework
     pub commands: Vec<crate::Command<U, E>>,
     /// Provide a callback to be invoked when any user code yields an error.
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub on_error: fn(crate::FrameworkError<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Called before every command
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub pre_command: fn(crate::Context<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Called after every command if it was successful (returned Ok)
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub post_command: fn(crate::Context<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Provide a callback to be invoked before every command. The command will only be executed
     /// if the callback returns true.
     ///
     /// If individual commands add their own check, both callbacks are run and must return true.
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub command_check: Option<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
     /// If set to true, skips command checks if command was issued by [`FrameworkOptions::owners`]
     pub skip_checks_for_owners: bool,
@@ -32,7 +30,7 @@ pub struct FrameworkOptions<U, E> {
     /// Invoked before every message sent using [`crate::Context::say`] or [`crate::Context::send`]
     ///
     /// Allows you to modify every outgoing message in a central place
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub reply_callback:
         Option<fn(crate::Context<'_, U, E>, crate::CreateReply) -> crate::CreateReply>,
     /// If `true`, disables automatic cooldown handling before every command invocation.
@@ -47,7 +45,7 @@ pub struct FrameworkOptions<U, E> {
     pub require_cache_for_guild_check: bool,
     /// Called on every Discord event. Can be used to react to non-command events, like messages
     /// deletions or guild updates.
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub event_handler: for<'a> fn(
         crate::FrameworkContext<'a, U, E>,
         &'a serenity::FullEvent,

--- a/src/structs/prefix.rs
+++ b/src/structs/prefix.rs
@@ -191,7 +191,10 @@ impl<U, E> Debug for PrefixFrameworkOptions<U, E> {
             .field("mention_as_prefix", &self.mention_as_prefix)
             .field("edit_tracker", &self.edit_tracker)
             .field("execute_untracked_edits", &self.execute_untracked_edits)
-            .field("ignore_edits_if_not_yet_responded", &self.ignore_edits_if_not_yet_responded)
+            .field(
+                "ignore_edits_if_not_yet_responded",
+                &self.ignore_edits_if_not_yet_responded,
+            )
             .field("execute_self_messages", &self.execute_self_messages)
             .field("ignore_bots", &self.ignore_bots)
             .field("ignore_thread_creation", &self.ignore_thread_creation)

--- a/src/structs/prefix.rs
+++ b/src/structs/prefix.rs
@@ -35,7 +35,6 @@ pub struct PrefixContext<'a, U, E> {
     /// Read-only reference to the framework
     ///
     /// Useful if you need the list of commands, for example for a custom help command
-    // #[derivative(Debug = "ignore")]
     pub framework: crate::FrameworkContext<'a, U, E>,
     /// If the invoked command was a subcommand, these are the parent commands, ordered top down.
     pub parent_commands: &'a [&'a crate::Command<U, E>],
@@ -46,7 +45,6 @@ pub struct PrefixContext<'a, U, E> {
     /// How this command invocation was triggered
     pub trigger: MessageDispatchTrigger,
     /// The function that is called to execute the actual command
-    // #[derivative(Debug = "ignore")]
     pub action: fn(
         PrefixContext<'_, U, E>,
     ) -> crate::BoxFuture<'_, Result<(), crate::FrameworkError<'_, U, E>>>,
@@ -57,7 +55,7 @@ pub struct PrefixContext<'a, U, E> {
 }
 
 // manual Debug impl to remove use of derivative proc macro
-impl<'a, U: Debug, E: Debug> Debug for PrefixContext<'a, U, E> {
+impl<'a, U, E> Debug for PrefixContext<'a, U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PrefixContext")
             .field("msg", &self.msg)
@@ -69,7 +67,7 @@ impl<'a, U: Debug, E: Debug> Debug for PrefixContext<'a, U, E> {
             .field("invocation_data", &self.invocation_data)
             .field("trigger", &self.trigger)
             .field("__non_exhaustive", &self.__non_exhaustive)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -127,7 +125,6 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// Ok(None)
     /// # })), ..Default::default() };
     /// ```
-    // #[derivative(Debug = "ignore")]
     pub stripped_dynamic_prefix: Option<
         for<'a> fn(
             &'a serenity::Context,
@@ -183,6 +180,25 @@ pub struct PrefixFrameworkOptions<U, E> {
     // #[non_exhaustive] forbids struct update syntax for ?? reason
     #[doc(hidden)]
     pub __non_exhaustive: (),
+}
+
+impl<U, E> Debug for PrefixFrameworkOptions<U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrefixFrameworkOptions")
+            .field("prefix", &self.prefix)
+            .field("additional_prefixes", &self.additional_prefixes)
+            .field("dynamic_prefix", &self.dynamic_prefix)
+            .field("mention_as_prefix", &self.mention_as_prefix)
+            .field("edit_tracker", &self.edit_tracker)
+            .field("execute_untracked_edits", &self.execute_untracked_edits)
+            .field("ignore_edits_if_not_yet_responded", &self.ignore_edits_if_not_yet_responded)
+            .field("execute_self_messages", &self.execute_self_messages)
+            .field("ignore_bots", &self.ignore_bots)
+            .field("ignore_thread_creation", &self.ignore_thread_creation)
+            .field("case_insensitive_commands", &self.case_insensitive_commands)
+            .field("non_command_message", &self.non_command_message)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<U, E> Default for PrefixFrameworkOptions<U, E> {

--- a/src/structs/prefix.rs
+++ b/src/structs/prefix.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::Cow;
 
+use std::fmt::Debug;
+
 use crate::{serenity_prelude as serenity, BoxFuture};
 
 /// The event that triggered a prefix command execution
@@ -21,8 +23,6 @@ pub enum MessageDispatchTrigger {
 /// Prefix-specific context passed to command invocations.
 ///
 /// Contains the trigger message, the Discord connection management stuff, and the user data.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct PrefixContext<'a, U, E> {
     /// The invoking user message
     pub msg: &'a serenity::Message,
@@ -35,7 +35,7 @@ pub struct PrefixContext<'a, U, E> {
     /// Read-only reference to the framework
     ///
     /// Useful if you need the list of commands, for example for a custom help command
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub framework: crate::FrameworkContext<'a, U, E>,
     /// If the invoked command was a subcommand, these are the parent commands, ordered top down.
     pub parent_commands: &'a [&'a crate::Command<U, E>],
@@ -46,7 +46,7 @@ pub struct PrefixContext<'a, U, E> {
     /// How this command invocation was triggered
     pub trigger: MessageDispatchTrigger,
     /// The function that is called to execute the actual command
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub action: fn(
         PrefixContext<'_, U, E>,
     ) -> crate::BoxFuture<'_, Result<(), crate::FrameworkError<'_, U, E>>>,
@@ -55,6 +55,24 @@ pub struct PrefixContext<'a, U, E> {
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
+
+// manual Debug impl to remove use of derivative proc macro
+impl<'a, U: Debug, E: Debug> Debug for PrefixContext<'a, U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrefixContext")
+            .field("msg", &self.msg)
+            .field("prefix", &self.prefix)
+            .field("invoked_command_name", &self.invoked_command_name)
+            .field("args", &self.args)
+            .field("parent_commands", &self.parent_commands)
+            .field("command", &self.command)
+            .field("invocation_data", &self.invocation_data)
+            .field("trigger", &self.trigger)
+            .field("__non_exhaustive", &self.__non_exhaustive)
+            .finish()
+    }
+}
+
 // manual Copy+Clone implementations because Rust is getting confused about the type parameter
 impl<U, E> Clone for PrefixContext<'_, U, E> {
     fn clone(&self) -> Self {
@@ -79,8 +97,6 @@ pub enum Prefix {
 }
 
 /// Prefix-specific framework configuration
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct PrefixFrameworkOptions<U, E> {
     /// The main bot prefix. Can be set to None if the bot supports only
     /// [dynamic prefixes](Self::dynamic_prefix).
@@ -94,7 +110,6 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// Override this field for a simple dynamic prefix which changes depending on the guild or user.
     ///
     /// For more advanced dynamic prefixes, see [`Self::stripped_dynamic_prefix`]
-    #[derivative(Debug = "ignore")]
     pub dynamic_prefix: Option<
         fn(crate::PartialContext<'_, U, E>) -> BoxFuture<'_, Result<Option<Cow<'static, str>>, E>>,
     >,
@@ -112,7 +127,7 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// Ok(None)
     /// # })), ..Default::default() };
     /// ```
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub stripped_dynamic_prefix: Option<
         for<'a> fn(
             &'a serenity::Context,

--- a/src/structs/slash.rs
+++ b/src/structs/slash.rs
@@ -1,5 +1,7 @@
 //! Holds application command definition structs.
 
+use std::fmt::Debug;
+
 use crate::{serenity_prelude as serenity, BoxFuture};
 
 use super::{CowStr, CowVec};
@@ -14,8 +16,6 @@ pub enum CommandInteractionType {
 }
 
 /// Application command specific context passed to command invocations.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct ApplicationContext<'a, U, E> {
     /// The interaction which triggered this command execution.
     pub interaction: &'a serenity::CommandInteraction,
@@ -34,7 +34,7 @@ pub struct ApplicationContext<'a, U, E> {
     /// Read-only reference to the framework
     ///
     /// Useful if you need the list of commands, for example for a custom help command
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub framework: crate::FrameworkContext<'a, U, E>,
     /// If the invoked command was a subcommand, these are the parent commands, ordered top down.
     pub parent_commands: &'a [&'a crate::Command<U, E>],
@@ -46,6 +46,23 @@ pub struct ApplicationContext<'a, U, E> {
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
+
+// manual Debug impl to remove use of derivative proc macro
+impl<'a, U: Debug, E: Debug> Debug for ApplicationContext<'a, U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApplicationContext")
+            .field("interaction", &self.interaction)
+            .field("interaction_type", &self.interaction_type)
+            .field("args", &self.args)
+            .field("has_sent_initial_response", &self.has_sent_initial_response)
+            .field("parent_commands", &self.parent_commands)
+            .field("command", &self.command)
+            .field("invocation_data", &self.invocation_data)
+            .field("__non_exhaustive", &self.__non_exhaustive)
+            .finish()
+    }
+}
+
 impl<U, E> Clone for ApplicationContext<'_, U, E> {
     fn clone(&self) -> Self {
         *self
@@ -80,12 +97,10 @@ impl<U, E> ApplicationContext<'_, U, E> {
 }
 
 /// Possible actions that a context menu entry can have
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub enum ContextMenuCommandAction<U, E> {
     /// Context menu entry on a user
     User(
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         fn(
             ApplicationContext<'_, U, E>,
             serenity::User,
@@ -93,7 +108,7 @@ pub enum ContextMenuCommandAction<U, E> {
     ),
     /// Context menu entry on a message
     Message(
-        #[derivative(Debug = "ignore")]
+        // #[derivative(Debug = "ignore")]
         fn(
             ApplicationContext<'_, U, E>,
             serenity::Message,
@@ -102,6 +117,18 @@ pub enum ContextMenuCommandAction<U, E> {
     #[doc(hidden)]
     __NonExhaustive,
 }
+
+// manual Debug impl to remove use of derivative proc macro
+impl<U: Debug, E: Debug> Debug for ContextMenuCommandAction<U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::User(_) => f.debug_tuple("User").finish(),
+            Self::Message(_) => f.debug_tuple("Message").finish(),
+            Self::__NonExhaustive => write!(f, "__NonExhaustive"),
+        }
+    }
+}
+
 impl<U, E> Copy for ContextMenuCommandAction<U, E> {}
 impl<U, E> Clone for ContextMenuCommandAction<U, E> {
     fn clone(&self) -> Self {
@@ -131,8 +158,6 @@ pub struct CommandParameterChoice {
 }
 
 /// A single parameter of a [`crate::Command`]
-#[derive(Clone, derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct CommandParameter<U, E> {
     /// Name of this command parameter
     pub name: CowStr,
@@ -159,12 +184,12 @@ pub struct CommandParameter<U, E> {
     /// |b| b.kind(serenity::CommandOptionType::Integer).min_int_value(0).max_int_value(u64::MAX)
     /// # ;
     /// ```
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub type_setter: Option<fn(serenity::CreateCommandOption) -> serenity::CreateCommandOption>,
     /// Optionally, a callback that is invoked on autocomplete interactions. This closure should
     /// extract the partial argument from the given JSON value and generate the autocomplete
     /// response which contains the list of autocomplete suggestions.
-    #[derivative(Debug = "ignore")]
+    // #[derivative(Debug = "ignore")]
     pub autocomplete_callback: Option<
         for<'a> fn(
             crate::ApplicationContext<'a, U, E>,
@@ -173,6 +198,22 @@ pub struct CommandParameter<U, E> {
     >,
     #[doc(hidden)]
     pub __non_exhaustive: (),
+}
+
+// manual Debug impl to remove use of derivative proc macro
+impl<U: Debug, E: Debug> Debug for CommandParameter<U, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommandParameter")
+            .field("name", &self.name)
+            .field("name_localizations", &self.name_localizations)
+            .field("description", &self.description)
+            .field("description_localizations", &self.description_localizations)
+            .field("required", &self.required)
+            .field("channel_types", &self.channel_types)
+            .field("choices", &self.choices)
+            .field("__non_exhaustive", &self.__non_exhaustive)
+            .finish()
+    }
 }
 
 impl<U, E> CommandParameter<U, E> {

--- a/src/structs/slash.rs
+++ b/src/structs/slash.rs
@@ -34,7 +34,6 @@ pub struct ApplicationContext<'a, U, E> {
     /// Read-only reference to the framework
     ///
     /// Useful if you need the list of commands, for example for a custom help command
-    // #[derivative(Debug = "ignore")]
     pub framework: crate::FrameworkContext<'a, U, E>,
     /// If the invoked command was a subcommand, these are the parent commands, ordered top down.
     pub parent_commands: &'a [&'a crate::Command<U, E>],
@@ -48,7 +47,7 @@ pub struct ApplicationContext<'a, U, E> {
 }
 
 // manual Debug impl to remove use of derivative proc macro
-impl<'a, U: Debug, E: Debug> Debug for ApplicationContext<'a, U, E> {
+impl<'a, U, E> Debug for ApplicationContext<'a, U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ApplicationContext")
             .field("interaction", &self.interaction)
@@ -59,7 +58,7 @@ impl<'a, U: Debug, E: Debug> Debug for ApplicationContext<'a, U, E> {
             .field("command", &self.command)
             .field("invocation_data", &self.invocation_data)
             .field("__non_exhaustive", &self.__non_exhaustive)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -119,11 +118,11 @@ pub enum ContextMenuCommandAction<U, E> {
 }
 
 // manual Debug impl to remove use of derivative proc macro
-impl<U: Debug, E: Debug> Debug for ContextMenuCommandAction<U, E> {
+impl<U, E> Debug for ContextMenuCommandAction<U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::User(_) => f.debug_tuple("User").finish(),
-            Self::Message(_) => f.debug_tuple("Message").finish(),
+            Self::User(_) => write!(f, "User"),
+            Self::Message(_) => write!(f, "Message"),
             Self::__NonExhaustive => write!(f, "__NonExhaustive"),
         }
     }
@@ -184,12 +183,10 @@ pub struct CommandParameter<U, E> {
     /// |b| b.kind(serenity::CommandOptionType::Integer).min_int_value(0).max_int_value(u64::MAX)
     /// # ;
     /// ```
-    // #[derivative(Debug = "ignore")]
     pub type_setter: Option<fn(serenity::CreateCommandOption) -> serenity::CreateCommandOption>,
     /// Optionally, a callback that is invoked on autocomplete interactions. This closure should
     /// extract the partial argument from the given JSON value and generate the autocomplete
     /// response which contains the list of autocomplete suggestions.
-    // #[derivative(Debug = "ignore")]
     pub autocomplete_callback: Option<
         for<'a> fn(
             crate::ApplicationContext<'a, U, E>,
@@ -201,7 +198,7 @@ pub struct CommandParameter<U, E> {
 }
 
 // manual Debug impl to remove use of derivative proc macro
-impl<U: Debug, E: Debug> Debug for CommandParameter<U, E> {
+impl<U, E> Debug for CommandParameter<U, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CommandParameter")
             .field("name", &self.name)
@@ -211,8 +208,7 @@ impl<U: Debug, E: Debug> Debug for CommandParameter<U, E> {
             .field("required", &self.required)
             .field("channel_types", &self.channel_types)
             .field("choices", &self.choices)
-            .field("__non_exhaustive", &self.__non_exhaustive)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
The Derivative proc-macro is unmaintained.

this pull request removes the macro from poise, and explicitly implements Debug for several structs instead.
