### PR TITLE
Ignore rustfmt::skip attribute when parsing parameter attributes

### DIFF
--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -185,6 +185,11 @@ pub fn command(
         let attrs: Vec<_> = pattern
             .attrs
             .drain(..)
+            .filter(|attr| {
+                !(attr.path().segments.len() == 2
+                    && attr.path().segments[0].ident == "rustfmt"
+                    && attr.path().segments[1].ident == "skip")
+            })
             .map(|attr| darling::ast::NestedMeta::Meta(attr.meta))
             .collect();
         let attrs = <ParamArgs as darling::FromMeta>::from_list(&attrs)?;


### PR DESCRIPTION
fixes #396.

It's okay to simply ignore it in this case, due to `#[rustfmt::skip]` being a purely source-code attribute used by rustfmt. There is no reason for it to be handled by poise (i.e., by including it in the expanded source.)