### PR TITLE
Fix CI on `current`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,10 @@ jobs:
             # don't test examples because they need collector feature
             command: cargo test --no-default-features --features serenity/rustls_backend --lib --tests
 
-          # - name: all features + simdjson
-          #   command: cargo test --all-features --features serenity/simdjson --lib --tests --examples
-          #   rustflags: -C target-cpu=haswell # needed for simdjson
+          - name: all features + simdjson
+            command: cargo test --all-features --features serenity/simd-json --lib --tests --examples
+            rustflags: -C target-cpu=haswell # for simd-json
+
           - name: all features - simdjson
             command: cargo test --all-features --lib --tests --examples
 
@@ -51,12 +52,11 @@ jobs:
             command: cargo test --all-features --features serenity/native_tls_backend --lib --tests --examples
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain || 'stable' }}
-          override: true
+      - uses: Swatinem/rust-cache@v2
       - run: ${{ matrix.command || 'cargo test --all-features' }}
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
@@ -65,46 +65,35 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - run: RUSTFLAGS="-C target-cpu=haswell" cargo clippy --all-features -- -D warnings
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-features -- -D warnings
+        env:
+          RUSTFLAGS: -C target-cpu=haswell # for simd-json
 
   docs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-      # don't use --no-deps because then intra-doc links to the macro crate won't work
-      - run: cargo +nightly doc --all-features -Z rustdoc-scrape-examples
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo +nightly rustdoc --all-features -Z rustdoc-scrape-examples -- --cfg doc_nightly -D rustdoc::broken_intra_doc_links
         env:
           RUSTFLAGS: -C target-cpu=haswell # for simd-json
-          RUSTDOCFLAGS: --cfg doc_nightly -D rustdoc::broken_intra_doc_links
 
       # If on current/next branch (as opposed to PR or whatever), publish docs to github pages
       - name: Move files
@@ -116,7 +105,7 @@ jobs:
           mv ./target/doc/* ./docs/$DIR/
       - name: Deploy docs
         if: github.ref == 'refs/heads/current' || github.ref == 'refs/heads/next'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ default-features = false
 features = ["builder", "client", "gateway", "model", "utils", "collector", "framework"]
 version = "0.12.5"
 
+# Example target required to enable example scraping
+[[example]]
+name = "quickstart"
+doc-scrape-examples = true
+
 [dev-dependencies]
 # For the examples
 tokio = { version = "1.25.1", features = ["rt-multi-thread"] }

--- a/examples/manual_dispatch/main.rs
+++ b/examples/manual_dispatch/main.rs
@@ -9,6 +9,7 @@ use poise::serenity_prelude as serenity;
 type Error = serenity::Error;
 
 #[poise::command(prefix_command)]
+#[allow(clippy::result_large_err)]
 async fn ping(ctx: poise::Context<'_, (), Error>) -> Result<(), Error> {
     ctx.say("Pong!").await?;
     Ok(())

--- a/src/builtins/pretty_help.rs
+++ b/src/builtins/pretty_help.rs
@@ -259,10 +259,7 @@ async fn pretty_help_single_command<U, E>(
         .reduce(|x, y| format!("{x}\n{y}"))
         .map(|s| ("Subcommands", s, false));
 
-    let fields = invocations
-        .into_iter()
-        .chain(parameters.into_iter())
-        .chain(sbcmds.into_iter());
+    let fields = invocations.into_iter().chain(parameters).chain(sbcmds);
 
     let embed = serenity::CreateEmbed::default()
         .description(description)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![doc(test(attr(deny(deprecated))))]
 // native #[non_exhaustive] is awful because you can't do struct update syntax with it (??)
 #![allow(clippy::manual_non_exhaustive)]
+// Fixing would require breaking changes, so allow on `current`.
+#![allow(clippy::result_large_err)]
 #![allow(clippy::type_complexity)]
 #![warn(
     clippy::missing_docs_in_private_items,

--- a/src/prefix_argument/code_block.rs
+++ b/src/prefix_argument/code_block.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for CodeBlock {
             f,
             "```{}\n{}\n```",
             self.language.as_deref().unwrap_or(""),
-            &self.code
+            self.code
         )
     }
 }


### PR DESCRIPTION
- Fixes Clippy failure
- Updates deprecated actions
- Adds cache actions
- Fixes doc scraping
- Restores/fixes simd-json test

The last four were already completed for `serenity-next` ([de8bd6f](https://github.com/serenity-rs/poise/commit/de8bd6fdd54de8ee5daf0242ffb6dc6eba58df69#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542)) but needed to be tweaked here since Serenity `current` still supports the `simd-json` feature.