### PR TITLE
Improve edit tracking to prevent unintended invocations

### DIFF
--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -92,14 +92,36 @@ pub async fn dispatch_event<U: Send + Sync, E>(
                 error.handle(framework.options).await;
             }
         }
-        serenity::FullEvent::MessageUpdate { event, .. } => {
+        serenity::FullEvent::MessageUpdate {
+            event,
+            old_if_available,
+            ..
+        } => {
             if let Some(edit_tracker) = &framework.options.prefix_options.edit_tracker {
+                #[cfg(feature = "cache")]
+                if framework.options().prefix_options.check_edits_against_cache {
+                    if let Some(old) = old_if_available {
+                        if event
+                            .content
+                            .as_deref()
+                            .is_some_and(|new_content| new_content == old.content)
+                        {
+                            return;
+                        }
+                    }
+                }
+
                 let msg = edit_tracker.write().unwrap().process_message_update(
                     event,
                     framework
                         .options()
                         .prefix_options
                         .ignore_edits_if_not_yet_responded,
+                    framework
+                        .options()
+                        .prefix_options
+                        .tracking_initiation_window
+                        .as_ref(),
                 );
 
                 if let Some((msg, previously_tracked)) = msg {

--- a/src/structs/prefix.rs
+++ b/src/structs/prefix.rs
@@ -126,19 +126,34 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// with the new result.
     pub edit_tracker: Option<std::sync::Arc<std::sync::RwLock<crate::EditTracker>>>,
     /// If the user makes a typo in their message and a subsequent edit creates a valid invocation,
-    /// the bot will execute the command if this attribute is set. [`Self::edit_tracker`] does not
-    /// need to be set for this.
+    /// the bot will execute the command if this attribute is set.
     ///
     /// That does not mean that any subsequent edits will also trigger execution. For that,
     /// see [`crate::Command::invoke_on_edit`].
     ///
-    /// Note: only has an effect if [`Self::edit_tracker`] is set.
+    /// Note: Only has an effect if [`Self::edit_tracker`] is set.
     pub execute_untracked_edits: bool,
     /// Whether to ignore message edits on messages that have not yet been responded to.
     ///
     /// This is the case if the message edit happens before a command has sent a response, or if the
     /// command does not send a response at all.
     pub ignore_edits_if_not_yet_responded: bool,
+    /// Whether to ignore message edits when the message was present in the message cache and the
+    /// content of the updated message is unchanged. Default is `true`.
+    ///
+    /// It is recommended to keep this on to prevent unintended command invocation.
+    ///
+    /// Note: Only has an effect if [`Self::edit_tracker`] is set and message caching is used.
+    #[cfg(feature = "cache")]
+    pub check_edits_against_cache: bool,
+    /// Optional window of time during which edit tracking may be initiated, beginning at message
+    /// creation. Default is 15 minutes.
+    ///
+    /// Setting a sensible duration is recommended to prevent unintended command invocations for
+    /// old messages, which can be triggered by both Discord and user edits.
+    ///
+    /// Note: Only has an effect if [`Self::edit_tracker`] is set.
+    pub tracking_initiation_window: Option<std::time::Duration>,
 
     /// Whether commands in messages emitted by this bot itself should be executed as well.
     pub execute_self_messages: bool,
@@ -181,6 +196,9 @@ impl<U, E> Default for PrefixFrameworkOptions<U, E> {
             edit_tracker: None,
             execute_untracked_edits: true,
             ignore_edits_if_not_yet_responded: false,
+            #[cfg(feature = "cache")]
+            check_edits_against_cache: true,
+            tracking_initiation_window: Some(std::time::Duration::from_secs(60 * 15)),
             execute_self_messages: false,
             ignore_bots: true,
             ignore_thread_creation: true,

--- a/src/track_edits.rs
+++ b/src/track_edits.rs
@@ -90,7 +90,16 @@ impl EditTracker {
         &mut self,
         user_msg_update: &serenity::MessageUpdateEvent,
         ignore_edits_if_not_yet_responded: bool,
+        tracking_initiation_window: Option<&std::time::Duration>,
     ) -> Option<(serenity::Message, bool)> {
+        if let Some(window) = tracking_initiation_window {
+            let created = user_msg_update.id.created_at().unix_timestamp();
+            let elapsed = serenity::Timestamp::now().unix_timestamp() - created;
+            if elapsed.unsigned_abs() > window.as_secs() {
+                return None;
+            }
+        }
+
         match self
             .cache
             .iter_mut()
@@ -102,11 +111,11 @@ impl EditTracker {
                 }
 
                 // If message content wasn't touched, don't re-run command
-                // Note: this may be Some, but still identical to previous content. We want to
-                // re-run the command in that case too; because that means the user explicitly
-                // edited their message
-                #[allow(clippy::question_mark)]
-                if user_msg_update.content.is_none() {
+                if user_msg_update
+                    .content
+                    .as_deref()
+                    .is_some_and(|content| content == invocation.user_msg.content)
+                {
                     return None;
                 }
 


### PR DESCRIPTION
Supersedes [#355](https://github.com/serenity-rs/poise/pull/355) and fixes [#309](https://github.com/serenity-rs/poise/issues/309).

This PR helps prevent unintended command invocation by placing sensible limits on edit tracking by default.
- `tracking_initiation_window` limits initiation of edit tracking to a specified duration of time (default is 15 minutes), starting at message creation.
- `check_edits_against_cache` prevents edit tracking if the old message was in the cache and the new message content is unchanged.

Initiation window is checked using `Timestamp::now()` instead of `edited_timestamp` since offending message update events can be triggered without editing, meaning we're interested in duration from message creation to update event dispatch.

The original PR ([#355](https://github.com/serenity-rs/poise/pull/355)) included `ignore_suppress_embeds_toggle`, but this is no longer necessary. Content is now always `Some`, so for tracked edits, we can just check for content changes against the invocation message (mirrors `serenity-next` behavior).

`check_edits_against_cache` is a hybrid alternative to the original `only_run_on_cached_message` and `ignore_suppress_embeds_toggle` for untracked edits, which only worked if the cached message was available.

Making `only_run_on_cached_message` the default didn't make sense since cached messages is `0` by default in Serenity, which would have effectively disabled edit tracking by default. Returning from the event handler when the cached message is available and content is unchanged simplifies the PR, offers an earlier return when possible, and achieves similar untracked edit behavior.