### PR TITLE
Add file types for slash commands

### DIFF
--- a/.github/Cargo-msrv.lock
+++ b/.github/Cargo-msrv.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.12.5"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#6910f64e15bfb8a6ca7e9aee604c33e303fa188a"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#37b9f433ada8b9ccc5f93f04826403b175855f86"
 dependencies = [
  "aformat",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.12.5"
-source = "git+https://github.com/serenity-rs/serenity?branch=next#6910f64e15bfb8a6ca7e9aee604c33e303fa188a"
+source = "git+https://github.com/serenity-rs/serenity?branch=next#37b9f433ada8b9ccc5f93f04826403b175855f86"
 dependencies = [
  "aformat",
  "arrayvec",

--- a/examples/feature_showcase/parameter_attributes.rs
+++ b/examples/feature_showcase/parameter_attributes.rs
@@ -46,6 +46,21 @@ pub async fn voiceinfo(
     Ok(())
 }
 
+/// Demonstrates `#[file_types]`
+#[poise::command(slash_command)]
+pub async fn display_text(
+    ctx: Context<'_>,
+    #[description = "Text file to send as a message"]
+    #[file_types(".txt")]
+    file: serenity::Attachment,
+) -> Result<(), Error> {
+    let file = file.download().await?;
+    let response = str::from_utf8(file.as_slice())?;
+
+    ctx.say(response).await?;
+    Ok(())
+}
+
 /// Parses arguments starting from the end of the string.
 ///
 /// Demonstrates `#[lazy]`

--- a/examples/feature_showcase/track_edits.rs
+++ b/examples/feature_showcase/track_edits.rs
@@ -7,7 +7,7 @@ pub async fn test_reuse_response(ctx: Context<'_>) -> Result<(), Error> {
 
     let embed = serenity::CreateEmbed::default()
         .description("embed 1")
-        .image(image_url);
+        .image(image_url, Some("Serenity logo".into()));
 
     let buttons = [serenity::CreateButton::new("1")
         .label("button 1")
@@ -28,7 +28,7 @@ pub async fn test_reuse_response(ctx: Context<'_>) -> Result<(), Error> {
     let image_url = "https://raw.githubusercontent.com/serenity-rs/serenity/current/examples/e09_create_message_builder/ferris_eyes.png";
     let embed = serenity::CreateEmbed::default()
         .description("embed 2")
-        .image(image_url);
+        .image(image_url, Some("Ferris with big eyes".into()));
 
     let buttons = [serenity::CreateButton::new("2")
         .label("button 2")

--- a/macros/src/command/mod.rs
+++ b/macros/src/command/mod.rs
@@ -75,6 +75,7 @@ struct ParamArgs {
     description_localized: Vec<crate::util::Tuple2<String>>,
     autocomplete: Option<syn::Path>,
     channel_types: Option<crate::util::List<syn::Ident>>,
+    file_types: Option<crate::util::List<syn::Lit>>,
     choices: Option<crate::util::List<syn::Lit>>,
     min: Option<syn::Lit>,
     max: Option<syn::Lit>,

--- a/macros/src/command/slash.rs
+++ b/macros/src/command/slash.rs
@@ -118,6 +118,13 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
             None => quote::quote! { None },
         };
 
+        let file_types = match &param.args.file_types {
+            Some(crate::util::List(file_types)) => quote::quote! { Some(
+                Cow::Borrowed(&[ #( Cow::Borrowed(#file_types) ),* ])
+            ) },
+            None => quote::quote! { None },
+        };
+
         parameter_structs.push((
             quote::quote! {
                 ::poise::CommandParameter {
@@ -127,6 +134,7 @@ pub fn generate_parameters(inv: &Invocation) -> Result<Vec<proc_macro2::TokenStr
                     description_localizations: #desc_localizations,
                     required: #required,
                     channel_types: #channel_types,
+                    file_types: #file_types,
                     type_setter: #type_setter,
                     choices: #choices,
                     autocomplete_callback: #autocomplete_callback,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -104,6 +104,7 @@ attributes you can use on parameters:
 ## Input filter (slash only)
 
 - `#[channel_types("", "")]`: For channel parameters, restricts allowed channel types (slash-only)
+- `#[file_types("", "")`: For attachment parameters, restricts allowed file types (slash-only)
 - `#[min = 0]`: Minimum value for this number parameter (slash-only)
 - `#[max = 0]`: Maximum value for this number parameter (slash-only)
 - `#[min_length = 0]`: Minimum length for this string parameter (slash-only)

--- a/src/dispatch/permissions/application.rs
+++ b/src/dispatch/permissions/application.rs
@@ -16,8 +16,8 @@ pub(super) fn get_author_and_bot_permissions(
 
     let mut bot_permissions = interaction.app_permissions;
 
-    let channel = interaction.channel.as_ref();
-    if channel.is_some_and(|c| matches!(c, serenity::GenericInteractionChannel::Thread(_))) {
+    let channel = &interaction.channel;
+    if matches!(channel, serenity::GenericInteractionChannel::Thread(_)) {
         author_permissions.set(
             Permissions::SEND_MESSAGES,
             author_permissions.send_messages_in_threads(),

--- a/src/prefix_argument/code_block.rs
+++ b/src/prefix_argument/code_block.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for CodeBlock {
             f,
             "```{}\n{}\n```",
             self.language.as_deref().unwrap_or(""),
-            &self.code
+            self.code
         )
     }
 }

--- a/src/structs/slash.rs
+++ b/src/structs/slash.rs
@@ -143,12 +143,14 @@ pub struct CommandParameter<U, E> {
     pub description: Option<CowStr>,
     /// Localized descriptions with locale string as the key (slash-only)
     pub description_localizations: CowVec<(CowStr, CowStr)>,
-    /// `true` is this parameter is required, `false` if it's optional or variadic
+    /// `true` if this parameter is required, `false` if it's optional or variadic
     pub required: bool,
     /// If this parameter is a channel, users can only enter these channel types in a slash command
     ///
     /// Prefix commands are currently unaffected by this
     pub channel_types: Option<CowVec<serenity::ChannelType>>,
+    /// If this parameter is an attachment, users can only upload these file types (slash-only)
+    pub file_types: Option<CowVec<CowStr>>,
     /// If this parameter is a choice parameter, this is the fixed list of options
     pub choices: CowVec<CommandParameterChoice>,
     /// Closure that sets this parameter's type and min/max value in the given builder
@@ -204,6 +206,9 @@ impl<U, E> CommandParameter<U, E> {
         }
         if let Some(channel_types) = self.channel_types.as_deref() {
             builder = builder.channel_types(channel_types.to_owned());
+        }
+        if let Some(file_types) = self.file_types.as_deref() {
+            builder = builder.file_types(file_types.to_owned());
         }
         for (i, choice) in self.choices.iter().enumerate() {
             builder = builder.add_int_choice_localized(


### PR DESCRIPTION
Fixes breakage from Serenity `next` [#3565](https://github.com/serenity-rs/serenity/pull/3565)/[#3597](https://github.com/serenity-rs/serenity/pull/3597) and adds support for file type filtering in slash commands (extension of `next` [#3596](https://github.com/serenity-rs/serenity/pull/3596)).
