### PR TITLE
Fix `Modal::execute_with_defaults` with `None`

### DIFF
--- a/macros/src/modal.rs
+++ b/macros/src/modal.rs
@@ -72,8 +72,10 @@ pub fn modal(input: syn::DeriveInput) -> Result<TokenStream, darling::Error> {
                     // Can use `defaults.#field_ident` directly in Edition 2021 due to more
                     // specific closure capture rules
                     let default = std::mem::take(&mut defaults.#field_ident);
-                    // Option::from().unwrap_or_default() dance to handle both T and Option<T>
-                    b = b.value(Option::from(default).unwrap_or_else(String::new));
+                    // Option::from() dance to handle both T and Option<T>
+                    if let Some(default) = Option::<String>::from(default) {
+                        b = b.value(default);
+                    }
                 }
                 b
                     #( .placeholder(#placeholder) )*


### PR DESCRIPTION
Currently, a default value passed to `Modal::execute_with_defaults` is wrapped in an `Option` and then unwrapped to the contained value or default, to handle both `T` and `Option<T>`. This has worked well for most cases, but when a `min_length` is specified and a default value of `None` is given, Poise passes the `None` in as `String::new()`, which results in an `Invalid Form Body` error from Discord. This PR avoids passing in a value when a default is set to `None`.