### PR TITLE
Replace `derivative` with `derive_where`

### DIFF
--- a/.github/Cargo-msrv.lock
+++ b/.github/Cargo-msrv.lock
@@ -293,14 +293,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "derive-where"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1023,7 +1023,7 @@ name = "poise"
 version = "0.6.1"
 dependencies = [
  "async-trait",
- "derivative",
+ "derive-where",
  "fluent",
  "fluent-syntax",
  "futures",
@@ -1591,17 +1591,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,14 +293,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "derive-where"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1023,7 +1023,7 @@ name = "poise"
 version = "0.6.1"
 dependencies = [
  "async-trait",
- "derivative",
+ "derive-where",
  "fluent",
  "fluent-syntax",
  "futures",
@@ -1591,17 +1591,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ poise_macros = { path = "macros", version = "0.6.1" } # remember to update the v
 async-trait = { version = "0.1.48", default-features = false } # various traits
 regex = { version = "1.6.0", default-features = false, features = ["std"] } # prefix
 tracing = { version = "0.1.40", features = ["log"] } # warning about weird state
-derivative = "2.2.0"
+derive-where = "1.6.1"
 parking_lot = "0.12.1"
 trim-in-place = "0.1.7"
 indexmap = "2.2.6"

--- a/src/structs/command.rs
+++ b/src/structs/command.rs
@@ -6,19 +6,18 @@ use super::{CowStr, CowVec};
 
 /// Type returned from `#[poise::command]` annotated functions, which contains all of the generated
 /// prefix and application commands
-#[derive(derivative::Derivative)]
-#[derivative(Default(bound = ""), Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub struct Command<U, E> {
     // =============
     /// Callback to execute when this command is invoked in a prefix context
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub prefix_action: Option<
         for<'a> fn(
             crate::PrefixContext<'a, U, E>,
         ) -> BoxFuture<'a, Result<(), crate::FrameworkError<'a, U, E>>>,
     >,
     /// Callback to execute when this command is invoked in a slash context
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub slash_action: Option<
         for<'a> fn(
             crate::ApplicationContext<'a, U, E>,
@@ -107,17 +106,16 @@ pub struct Command<U, E> {
     /// If true, the command may only run in NSFW channels
     pub nsfw_only: bool,
     /// Command-specific override for [`crate::FrameworkOptions::on_error`]
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub on_error: Option<fn(crate::FrameworkError<'_, U, E>) -> BoxFuture<'_, ()>>,
     /// If any of these functions returns false, this command will not be executed.
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub checks: Vec<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
     /// List of parameters for this command
     ///
     /// Used for registering and parsing slash commands. Can also be used in help commands
     pub parameters: Vec<crate::CommandParameter<U, E>>,
     /// Arbitrary data, useful for storing custom metadata about your commands
-    #[derivative(Default(value = "Box::new(())"))]
     pub custom_data: Box<dyn std::any::Any + Send + Sync>,
 
     // ============= Prefix-specific data
@@ -273,5 +271,51 @@ impl<U, E> Command<U, E> {
         }
 
         Some(builder)
+    }
+}
+
+impl<U, E> Default for Command<U, E> {
+    fn default() -> Self {
+        Self {
+            prefix_action: None,
+            slash_action: None,
+            context_menu_action: None,
+            subcommands: Vec::new(),
+            subcommand_required: false,
+            name: CowStr::default(),
+            name_localizations: CowVec::default(),
+            qualified_name: CowStr::default(),
+            identifying_name: CowStr::default(),
+            source_code_name: CowStr::default(),
+            category: None,
+            hide_in_help: false,
+            description: None,
+            description_localizations: CowVec::default(),
+            help_text: None,
+            manual_cooldowns: None,
+            cooldowns: std::sync::Mutex::default(),
+            cooldown_config: std::sync::RwLock::default(),
+            reuse_response: false,
+            default_member_permissions: serenity::Permissions::empty(),
+            required_permissions: serenity::Permissions::empty(),
+            required_bot_permissions: serenity::Permissions::empty(),
+            owners_only: false,
+            guild_only: false,
+            dm_only: false,
+            nsfw_only: false,
+            on_error: None,
+            checks: Vec::new(),
+            parameters: Vec::new(),
+            custom_data: Box::new(()),
+            aliases: CowVec::default(),
+            invoke_on_edit: false,
+            track_deletion: false,
+            broadcast_typing: false,
+            context_menu_name: None,
+            ephemeral: false,
+            install_context: None,
+            interaction_context: None,
+            __non_exhaustive: (),
+        }
     }
 }

--- a/src/structs/framework_error.rs
+++ b/src/structs/framework_error.rs
@@ -6,8 +6,7 @@ use crate::serenity_prelude as serenity;
 /// have an `error` field with your error type `E` in it), or originating from within the framework.
 ///
 /// These errors are handled with the [`crate::FrameworkOptions::on_error`] callback
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive_where::derive_where(Debug; U, E)]
 pub enum FrameworkError<'a, U, E> {
     /// User code threw an error in user data setup
     #[non_exhaustive]
@@ -15,12 +14,12 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the setup code
         error: E,
         /// The Framework passed to the event
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         framework: &'a crate::Framework<U, E>,
         /// Discord Ready event data present during setup
         data_about_bot: &'a serenity::Ready,
         /// The serenity Context passed to the event
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         ctx: &'a serenity::Context,
     },
     /// User code threw an error in generic event event handler
@@ -31,7 +30,7 @@ pub enum FrameworkError<'a, U, E> {
         /// Which event was being processed when the error occurred
         event: &'a serenity::FullEvent,
         /// The Framework passed to the event
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         framework: crate::FrameworkContext<'a, U, E>,
     },
     /// Error occurred during command execution
@@ -163,7 +162,7 @@ pub enum FrameworkError<'a, U, E> {
         /// Error which was thrown in the dynamic prefix code
         error: E,
         /// General context
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         ctx: crate::PartialContext<'a, U, E>,
         /// Message which the dynamic prefix callback was evaluated upon
         msg: &'a serenity::Message,
@@ -176,10 +175,10 @@ pub enum FrameworkError<'a, U, E> {
         /// The position in the message that the prefix ends.
         content_start: u16,
         /// Framework context
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         framework: crate::FrameworkContext<'a, U, E>,
         /// See [`crate::Context::invocation_data`]
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         invocation_data: &'a tokio::sync::Mutex<Box<dyn std::any::Any + Send + Sync>>,
         /// Which event triggered the message parsing routine
         trigger: crate::MessageDispatchTrigger,
@@ -188,7 +187,7 @@ pub enum FrameworkError<'a, U, E> {
     #[non_exhaustive]
     UnknownInteraction {
         /// Framework context
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         framework: crate::FrameworkContext<'a, U, E>,
         /// The interaction in question
         interaction: &'a serenity::CommandInteraction,
@@ -199,7 +198,7 @@ pub enum FrameworkError<'a, U, E> {
         /// The error thrown by user code
         error: E,
         /// Framework context
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         framework: crate::FrameworkContext<'a, U, E>,
         /// The interaction in question
         msg: &'a serenity::Message,

--- a/src/structs/framework_options.rs
+++ b/src/structs/framework_options.rs
@@ -3,25 +3,24 @@
 use crate::{serenity_prelude as serenity, BoxFuture};
 
 /// Framework configuration
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub struct FrameworkOptions<U, E> {
     /// List of commands in the framework
     pub commands: Vec<crate::Command<U, E>>,
     /// Provide a callback to be invoked when any user code yields an error.
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub on_error: fn(crate::FrameworkError<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Called before every command
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub pre_command: fn(crate::Context<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Called after every command if it was successful (returned Ok)
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub post_command: fn(crate::Context<'_, U, E>) -> BoxFuture<'_, ()>,
     /// Provide a callback to be invoked before every command. The command will only be executed
     /// if the callback returns true.
     ///
     /// If individual commands add their own check, both callbacks are run and must return true.
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub command_check: Option<fn(crate::Context<'_, U, E>) -> BoxFuture<'_, Result<bool, E>>>,
     /// If set to true, skips command checks if command was issued by [`FrameworkOptions::owners`]
     pub skip_checks_for_owners: bool,
@@ -32,7 +31,7 @@ pub struct FrameworkOptions<U, E> {
     /// Invoked before every message sent using [`crate::Context::say`] or [`crate::Context::send`]
     ///
     /// Allows you to modify every outgoing message in a central place
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub reply_callback:
         Option<fn(crate::Context<'_, U, E>, crate::CreateReply) -> crate::CreateReply>,
     /// If `true`, disables automatic cooldown handling before every command invocation.
@@ -47,7 +46,7 @@ pub struct FrameworkOptions<U, E> {
     pub require_cache_for_guild_check: bool,
     /// Called on every Discord event. Can be used to react to non-command events, like messages
     /// deletions or guild updates.
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub event_handler: for<'a> fn(
         crate::FrameworkContext<'a, U, E>,
         &'a serenity::FullEvent,

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,5 +1,4 @@
 //! Plain data structs that define the framework configuration.
-#![allow(clippy::needless_lifetimes)] // Triggered from inside derivative
 
 use std::borrow::Cow;
 

--- a/src/structs/prefix.rs
+++ b/src/structs/prefix.rs
@@ -21,8 +21,7 @@ pub enum MessageDispatchTrigger {
 /// Prefix-specific context passed to command invocations.
 ///
 /// Contains the trigger message, the Discord connection management stuff, and the user data.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub struct PrefixContext<'a, U, E> {
     /// The invoking user message
     pub msg: &'a serenity::Message,
@@ -35,7 +34,7 @@ pub struct PrefixContext<'a, U, E> {
     /// Read-only reference to the framework
     ///
     /// Useful if you need the list of commands, for example for a custom help command
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub framework: crate::FrameworkContext<'a, U, E>,
     /// The command invoked by this message.
     ///
@@ -75,8 +74,7 @@ pub enum Prefix {
 }
 
 /// Prefix-specific framework configuration
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub struct PrefixFrameworkOptions<U, E> {
     /// The main bot prefix. Can be set to None if the bot supports only
     /// [dynamic prefixes](Self::dynamic_prefix).
@@ -90,7 +88,7 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// Override this field for a simple dynamic prefix which changes depending on the guild or user.
     ///
     /// For more advanced dynamic prefixes, see [`Self::stripped_dynamic_prefix`]
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub dynamic_prefix: Option<
         fn(crate::PartialContext<'_, U, E>) -> BoxFuture<'_, Result<Option<Cow<'static, str>>, E>>,
     >,
@@ -108,7 +106,7 @@ pub struct PrefixFrameworkOptions<U, E> {
     /// Ok(None)
     /// # })), ..Default::default() };
     /// ```
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub stripped_dynamic_prefix: Option<
         for<'a> fn(
             &'a serenity::Context,

--- a/src/structs/slash.rs
+++ b/src/structs/slash.rs
@@ -14,8 +14,7 @@ pub enum CommandInteractionType {
 }
 
 /// Application command specific context passed to command invocations.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub struct ApplicationContext<'a, U, E> {
     /// The interaction which triggered this command execution.
     pub interaction: &'a serenity::CommandInteraction,
@@ -34,7 +33,7 @@ pub struct ApplicationContext<'a, U, E> {
     /// Read-only reference to the framework
     ///
     /// Useful if you need the list of commands, for example for a custom help command
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub framework: crate::FrameworkContext<'a, U, E>,
     /// The command invoked by this interaction.
     ///
@@ -81,12 +80,11 @@ impl<U, E> ApplicationContext<'_, U, E> {
 }
 
 /// Possible actions that a context menu entry can have
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub enum ContextMenuCommandAction<U, E> {
     /// Context menu entry on a user
     User(
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         fn(
             ApplicationContext<'_, U, E>,
             serenity::User,
@@ -94,7 +92,7 @@ pub enum ContextMenuCommandAction<U, E> {
     ),
     /// Context menu entry on a message
     Message(
-        #[derivative(Debug = "ignore")]
+        #[derive_where(skip)]
         fn(
             ApplicationContext<'_, U, E>,
             serenity::Message,
@@ -132,8 +130,7 @@ pub struct CommandParameterChoice {
 }
 
 /// A single parameter of a [`crate::Command`]
-#[derive(Clone, derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive_where::derive_where(Debug)]
 pub struct CommandParameter<U, E> {
     /// Name of this command parameter
     pub name: CowStr,
@@ -160,12 +157,12 @@ pub struct CommandParameter<U, E> {
     /// |b| b.kind(serenity::CommandOptionType::Integer).min_int_value(0).max_int_value(u64::MAX)
     /// # ;
     /// ```
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub type_setter: Option<fn(serenity::CreateCommandOption) -> serenity::CreateCommandOption>,
     /// Optionally, a callback that is invoked on autocomplete interactions. This closure should
     /// extract the partial argument from the given JSON value and generate the autocomplete
     /// response which contains the list of autocomplete suggestions.
-    #[derivative(Debug = "ignore")]
+    #[derive_where(skip)]
     pub autocomplete_callback: Option<
         for<'a> fn(
             crate::ApplicationContext<'a, U, E>,


### PR DESCRIPTION
Supersedes [#392](https://github.com/serenity-rs/poise/pull/392) and closes [#334](https://github.com/serenity-rs/poise/issues/334).

Replaces the unmaintained `derivative` crate with `derive_where`.

I initially intended to switch to `derive_more` since there is an open PR for deriving `Default`, but `derive_more` only supports _additional_ bounds, which made it impossible to replicate `derivative`'s `bound = ""` functionality. With `derive_where`, I was able to produce equivalent expanded code. The only difference is that `derive_where` properly indicates `non_exhaustive` (`{ , .. }`), while `derivative` did not, but this is more accurate.

Since we only used `derivative` to derive `Default` for `Command`, I just added the manual implementation for that.

Verified that all expanded code is functionally equivalent and confirmed that `Debug` output displays properly.